### PR TITLE
MOCO-1269 Log X-Request-ID 

### DIFF
--- a/http/src/main/scala/com/pagerduty/akka/http/support/GenericErrorHandling.scala
+++ b/http/src/main/scala/com/pagerduty/akka/http/support/GenericErrorHandling.scala
@@ -1,21 +1,24 @@
 package com.pagerduty.akka.http.support
 
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
-import akka.http.scaladsl.server.Directives.complete
+import akka.http.scaladsl.server.Directives.{complete, extractRequest}
 import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler}
 import com.pagerduty.metrics.Metrics
-import org.slf4j.Logger
 
-trait GenericErrorHandling {
+trait GenericErrorHandling extends Logging {
 
   /**
     * Useful for catching and completing unhandled exceptions before they propagate through logging or metrics directives.
     */
   lazy val exceptionHandler = ExceptionHandler {
     case e =>
-      metrics.increment("server_error", ("exception", e.getClass.getSimpleName))
-      log.error(s"Exception handling request: $e")
-      complete(HttpResponse(status = StatusCodes.InternalServerError))
+      extractRequest { req =>
+        implicit val reqCtx = RequestContext.fromRequest(req)
+
+        metrics.increment("server_error", ("exception", e.getClass.getSimpleName))
+        log.error(s"Exception handling request: $e")
+        complete(HttpResponse(status = StatusCodes.InternalServerError))
+      }
   }
 
   /**
@@ -27,6 +30,5 @@ trait GenericErrorHandling {
       .handleNotFound { complete(HttpResponse(status = StatusCodes.NotFound)) }
       .result()
 
-  def log: Logger
   def metrics: Metrics
 }

--- a/http/src/main/scala/com/pagerduty/akka/http/support/Logging.scala
+++ b/http/src/main/scala/com/pagerduty/akka/http/support/Logging.scala
@@ -1,0 +1,25 @@
+package com.pagerduty.akka.http.support
+
+import org.slf4j.LoggerFactory
+
+trait Logging {
+
+  /**
+    * This is based on com.pagerduty.bffpublicapi.util.Logging
+    */
+
+  val logBase = LoggerFactory.getLogger(getClass)
+
+  case class LoggingImpl(ctx: RequestContext) {
+    def prefix: String = ctx.reqId.map(id => s"[X-Request-ID: ${id}] ").getOrElse("")
+
+    def debug(msg: String): Unit = logBase.debug(prefix + msg)
+    def info(msg: String): Unit = logBase.info(prefix + msg)
+    def error(msg: String): Unit = logBase.error(prefix + msg)
+    def warn(msg: String): Unit = logBase.warn(prefix + msg)
+  }
+
+  def log(implicit ctx: RequestContext) = {
+    LoggingImpl(ctx)
+  }
+}

--- a/http/src/main/scala/com/pagerduty/akka/http/support/MetricsDirectives.scala
+++ b/http/src/main/scala/com/pagerduty/akka/http/support/MetricsDirectives.scala
@@ -3,9 +3,8 @@ package com.pagerduty.akka.http.support
 import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server.RouteResult.{Complete, Rejected}
 import com.pagerduty.metrics.{Metrics, Stopwatch}
-import org.slf4j.Logger
 
-trait MetricsDirectives {
+trait MetricsDirectives extends Logging {
   import akka.http.scaladsl.server.directives.BasicDirectives._
 
   /**
@@ -38,26 +37,31 @@ trait MetricsDirectives {
     * @param tags Any additional tags to include on the increment
     */
   def emitResponseCount(metricName: String, tags: (String, String)*): Directive0 = {
-    mapRouteResult {
-      case result: Complete =>
-        val statusCode = result.response.status.intValue
-        val responseErrorType = statusCode match {
-          case i if i >= 400 && i <= 499 => "client"
-          case i if i >= 500 && i <= 599 => "server"
-          case _ => "none"
-        }
-        val augmentedTags = tags ++ Seq(
-          ("response_code", statusCode.toString),
-          ("response_error_type", responseErrorType)
-        )
-        metrics.increment(metricName, augmentedTags: _*)
-        result
-      case result: Rejected =>
-        log.warn("Response code metric not emitted because it was not known yet")
-        log.warn(
-          "If you want to see a response code emitted here, ensure that exceptions/rejections are handled inside the emitResponseCodes directive"
-        )
-        result
+    extractRequestContext.flatMap { ctx =>
+      val req = ctx.request
+      implicit val reqCtx = RequestContext.fromRequest(req)
+
+      mapRouteResult {
+        case result: Complete =>
+          val statusCode = result.response.status.intValue
+          val responseErrorType = statusCode match {
+            case i if i >= 400 && i <= 499 => "client"
+            case i if i >= 500 && i <= 599 => "server"
+            case _ => "none"
+          }
+          val augmentedTags = tags ++ Seq(
+            ("response_code", statusCode.toString),
+            ("response_error_type", responseErrorType)
+          )
+          metrics.increment(metricName, augmentedTags: _*)
+          result
+        case result: Rejected =>
+          log.warn("Response code metric not emitted because it was not known yet")
+          log.warn(
+            "If you want to see a response code emitted here, ensure that exceptions/rejections are handled inside the emitResponseCodes directive"
+          )
+          result
+      }
     }
   }
 
@@ -72,5 +76,4 @@ trait MetricsDirectives {
   }
 
   def metrics: Metrics
-  def log: Logger
 }

--- a/http/src/main/scala/com/pagerduty/akka/http/support/RequestContext.scala
+++ b/http/src/main/scala/com/pagerduty/akka/http/support/RequestContext.scala
@@ -1,0 +1,17 @@
+package com.pagerduty.akka.http.support
+
+import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
+
+/**
+  * This is based on com.pagerduty.bffpublicapi.util.RequestContext
+  */
+
+case class RequestContext(reqId: Option[String]) {
+  val requestIdHeader: Option[HttpHeader] = reqId.map(r => RequestIdHeader(r))
+}
+
+object RequestContext {
+  def fromRequest(req: HttpRequest) = {
+    RequestContext(RequestIdHeader.extractRequestId(req))
+  }
+}

--- a/http/src/main/scala/com/pagerduty/akka/http/support/RequestIdHeader.scala
+++ b/http/src/main/scala/com/pagerduty/akka/http/support/RequestIdHeader.scala
@@ -1,0 +1,27 @@
+package com.pagerduty.akka.http.support
+
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.headers.{ModeledCustomHeader, ModeledCustomHeaderCompanion}
+
+import scala.util.Try
+
+/**
+  * This is based on com.pagerduty.bffpublicapi.util.RequestIdHeader
+  */
+
+final class RequestIdHeader(reqId: String) extends ModeledCustomHeader[RequestIdHeader] {
+  override def renderInRequests = true
+  override def renderInResponses = true
+  override val companion = RequestIdHeader
+  override def value: String = reqId
+}
+
+object RequestIdHeader extends ModeledCustomHeaderCompanion[RequestIdHeader] {
+  override val name = "X-Request-Id"
+  override def parse(value: String) = Try(new RequestIdHeader(value))
+
+  def extractRequestId(req: HttpRequest): Option[String] =
+    req.headers.collectFirst({
+      case RequestIdHeader(reqId) => reqId
+    })
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.2"
+version in ThisBuild := "0.5.0"


### PR DESCRIPTION
As per discussions with @DWvanGeest, we want to add the capability of logging `X-Request-ID` in this module so that we have consistent logging implementations/behaviour across different services. 

The changes here heavily borrow from @justinmichaud's [changes from CORE-1617](https://github.com/PagerDuty/bff-public-api/pull/36/files).

Summary of changes:
- Added a `RequestContext`class to encapsulate the request header.
- Added a `RequestIdHeader` class to represent the `X-Request-ID` header
- Added a `Logging` `trait` that prefixes all logs with the  `X-Request-ID` (provided one exists)
- Updated all instances where data is being logged to use the new `Logging` `trait` 