### PR TITLE
Fix SBT build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,27 +1,37 @@
-organization := "com.pagerduty"
-
-name := "akka-support-http"
-
-scalaVersion := "2.11.12"
-
-crossScalaVersions := Seq("2.11.12", "2.12.8")
-
-licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
-
-bintrayOrganization := Some("pagerduty")
-bintrayRepository := "oss-maven"
-
-publishMavenStyle := true
-
-resolvers := Seq(
-  "bintray-pagerduty-oss-maven" at "https://dl.bintray.com/pagerduty/oss-maven",
-  Resolver.defaultLocal
+lazy val sharedSettings = Seq(
+  organization := "com.pagerduty",
+  scalaVersion := "2.11.12",
+  crossScalaVersions := Seq("2.11.12", "2.12.8"),
+  licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
+  bintrayOrganization := Some("pagerduty"),
+  bintrayRepository := "oss-maven",
+  publishMavenStyle := true,
+  resolvers := Seq(
+    "bintray-pagerduty-oss-maven" at "https://dl.bintray.com/pagerduty/oss-maven",
+    Resolver.defaultLocal
+  )
 )
 
-libraryDependencies ++= Seq(
-  "org.slf4j" % "slf4j-api" % "1.7.+",
-  "com.typesafe.akka" %% "akka-http" % "10.1.7",
-  "com.pagerduty" %% "metrics-api" % "2.0.0"
-)
+lazy val http = (project in file("http"))
+  .settings(sharedSettings: _*)
+  .settings(
+    name := "akka-support-http",
+    libraryDependencies ++= Seq(
+      "org.slf4j" % "slf4j-api" % "1.7.+",
+      "com.typesafe.akka" %% "akka-http" % "10.1.7",
+      "com.typesafe.akka" %% "akka-stream" % "2.5.9",
+      "com.pagerduty" %% "metrics-api" % "2.0.0"
+    )
+  )
+
+lazy val root = (project in file("."))
+  .settings(sharedSettings: _*)
+  .settings(
+    publishLocal := {},
+    publish := {},
+    publishArtifact := false
+  )
+  .aggregate(http)
 
 scalafmtOnCompile in ThisBuild := true
+skip in publish := true


### PR DESCRIPTION
In the previous PR to migrate to CircleCI, build.sbt was simplified in
order to properly cross compile to all specified Scala versions.
However, as it turns out this caused nothing to actually get compiled.
This reverts said changes so that this library is properly cross
compiled and published.
Note that since v10.1.x `akka-http` requires `Sakka-stream`.