### PR TITLE
CORE-1969 Bump version to 0.7.1

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.0"
+version in ThisBuild := "0.7.1"


### PR DESCRIPTION
A previous broken build 0.7.0 is somehow being cached by Bintray. This should fix it.